### PR TITLE
Add Windows AMD64 executable for Velociraptor v0.74.3

### DIFF
--- a/bin/windows/README.md
+++ b/bin/windows/README.md
@@ -1,0 +1,29 @@
+# Velociraptor Windows AMD64 Executable
+
+This directory contains the pre-built Windows AMD64 executable for Velociraptor v0.74.3.
+
+## File Information
+
+- **Filename**: velociraptor.exe
+- **Version**: v0.74.3
+- **Architecture**: AMD64 (64-bit)
+- **Platform**: Windows
+- **Source**: Official Velociraptor release
+
+## Usage
+
+1. Download the executable to your Windows system
+2. Run the executable from the command line to see available options:
+   ```
+   velociraptor.exe --help
+   ```
+
+3. For detailed documentation, visit the [Velociraptor documentation](https://docs.velociraptor.app/)
+
+## Verification
+
+The original executable comes with a signature file that can be used to verify its authenticity. The signature files are available in the official Velociraptor releases.
+
+## License
+
+Velociraptor is licensed under the GNU Affero General Public License v3.0 (AGPLv3).


### PR DESCRIPTION
## Description

This PR adds the Windows AMD64 executable for Velociraptor v0.74.3 to the repository.

## Changes

- Added pre-built Windows AMD64 executable (v0.74.3) to bin/windows/
- Added README.md with information about the executable

## Notes

The executable was obtained from the official Velociraptor releases. GitHub has flagged the file as large (64.25 MB), which exceeds GitHub's recommended maximum file size of 50 MB. For future updates, consider using Git LFS for large binary files.